### PR TITLE
Added ARM64 support to sofa-jraft

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <project.encoding>UTF-8</project.encoding>
         <protobuf.version>3.5.1</protobuf.version>
         <protostuff.version>1.6.0</protostuff.version>
-        <rocksdb.version>5.18.3</rocksdb.version>
+        <rocksdb.version>5.18.4</rocksdb.version>
         <slf4j.version>1.7.21</slf4j.version>
     </properties>
 


### PR DESCRIPTION
**Hi**

**Package Owner:** Rahul Aggarwal

**PR change Details:**
**1. Patch Details:** Following file has been modified :
_pom.xml:_ Upgraded rocksdb version from 5.18.3 to 5.18.4 for AArch64 support.

**2. Testing Detail:**
Tested 'sofa-jraft' with 'openjdk-8-jdk' on Travis-CI.
Please find my Travis-CI testing jobs here: <https://travis-ci.com/github/ra9501576600git/sofa-jraft/builds/188048404>

**3. PR Description:** Here is my commit message :

Upgraded 'rocksdb' version to 5.18.4 for AArch64 support.

Signed-off-by: odidev <odidev@puresoftware.com>

**4. Peer Reviewer:** Pruthvi Teja
**5. Reviewer:** Rajeev Nayan

**Thanks
Rahul Aggarwal**